### PR TITLE
Add call to PR_SET_NO_NEW_PRIVS after of drop privileges.

### DIFF
--- a/jchroot.c
+++ b/jchroot.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>
+#include <sys/prctl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
@@ -98,6 +99,10 @@ static int step6(struct config *config) {
   }
   if (config->user != (uid_t) -1 && setuid(config->user)) {
     fprintf(stderr, "unable to change to UID %d: %m\n", config->user);
+    return EXIT_FAILURE;
+  }
+  if ((config->group != (gid_t) -1 || config->user != (uid_t) -1) && prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
+    fprintf(stderr, "unable to disable new privs");
     return EXIT_FAILURE;
   }
   return step7(config);

--- a/jchroot.c
+++ b/jchroot.c
@@ -101,10 +101,11 @@ static int step6(struct config *config) {
     fprintf(stderr, "unable to change to UID %d: %m\n", config->user);
     return EXIT_FAILURE;
   }
-  if ((config->group != (gid_t) -1 || config->user != (uid_t) -1) && prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
-    fprintf(stderr, "unable to disable new privs");
-    return EXIT_FAILURE;
+  #ifdef PR_SET_NO_NEW_PRIVS
+  if (config->group != (gid_t) -1 || config->user != (uid_t) -1) {
+    prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
   }
+  #endif
   return step7(config);
 }
 


### PR DESCRIPTION
With NO_NEW_PRIVS UID and GID is more strict (http://man7.org/linux/man-pages/man2/prctl.2.html) and can be other crash barrier. I only don't understand main function and arguments for add it with and argument for enabled or disabled it.

It can compile and run, I check it. Also, can be useful seccomp with option for use strict mode and filter mode, after of drop privilegies and before of execvp, for filter syscall that executed command will be use.
