### PR TITLE
Add -v option for setting environment variables using putenv().

### DIFF
--- a/jchroot.8
+++ b/jchroot.8
@@ -29,6 +29,7 @@
 .Op Fl n Ar hostname
 .Op Fl M Ar map
 .Op Fl G Ar map
+.Op Fl v Ar name=value
 .Ar target
 .Op --
 .Ar command
@@ -101,6 +102,8 @@ sys      /sys   sysfs   defaults                  0  0
 .Ed
 .It Fl n , -hostname Ar name
 Specify a hostname for the chroot. This enables UTS namespace.
+.It Fl v Ar name=value
+Set an environment variable. This option can be specified more than once.
 .It Fl h
 Get help.
 .El

--- a/jchroot.c
+++ b/jchroot.c
@@ -370,7 +370,7 @@ int main(int argc, char * argv[]) {
       { 0,          0,                 0, 0   }
     };
 
-    c = getopt_long(argc, argv, "hNUu:g:f:n:M:G:",
+    c = getopt_long(argc, argv, "hNUu:g:f:n:M:G:v:",
 		    long_options, &option_index);
     if (c == -1) break;
 
@@ -426,6 +426,13 @@ int main(int argc, char * argv[]) {
     case 'n':
       if (!optarg) usage();
       config.hostname = optarg;
+      break;
+    case 'v':
+      if (!optarg) usage();
+      if (putenv(optarg) != 0) {
+	fprintf(stderr, "failed to set environment variable: %s\n", optarg);
+	usage();
+      }
       break;
     default:
       usage();


### PR DESCRIPTION
Please add this important feature. It's helpful to services that rely on variables like HOME. With it we'd no longer require having /usr/bin/env inside the chroot directory.

I chose -v option based from awk's.
