### PR TITLE
close pipe after it's been used

### DIFF
--- a/jchroot.c
+++ b/jchroot.c
@@ -206,6 +206,11 @@ static int step3(void *arg) {
     fprintf(stderr, "unable to synchronize with parent: %m\n");
     return EXIT_FAILURE;
   }
+  
+  close(config->pipe_fd[0]);
+  /* Make sure we have no handles shared with parent anymore,
+   * these might be used to break out of the chroot */
+  unshare(CLONE_FILES);
 
   if (config->fstab) {
     struct mntent *mntent;


### PR DESCRIPTION
The pipe between parent and child should be closed. Additionally unshare CLONE_FILES as we don't need shared file descriptors anymore, and these could worst case be used to break out of the chroot.
