### PR TITLE
Add -p/--pidfile option.

### DIFF
--- a/jchroot.8
+++ b/jchroot.8
@@ -29,6 +29,7 @@
 .Op Fl n Ar hostname
 .Op Fl M Ar map
 .Op Fl G Ar map
+.Op Fl p Ar pidfile
 .Op Fl e Ar name=value
 .Ar target
 .Op --
@@ -102,6 +103,8 @@ sys      /sys   sysfs   defaults                  0  0
 .Ed
 .It Fl n , -hostname Ar name
 Specify a hostname for the chroot. This enables UTS namespace.
+.It Fl p , -pidfile Ar file
+Write PID of child process to file.
 .It Fl e Ar name=value
 Set an environment variable. This option can be specified more than once.
 .It Fl h


### PR DESCRIPTION
This makes jchroot write the PID of the child process to a file.

When creating a daemon that is created by jchroot at boot-time with an init manager like OpenRC, it is important that the actual child process that does the main function be the one to have its PID recorded in a file, or else when the service is called to stop, only the process of jchroot gets terminated, and the child process running in the chrooted environment remains running.  This is why it would be helpful to have this feature.  Without it I would need to do something like this:

```
ebegin "Starting chrooted Tor using /usr/bin/jchroot"

start_stop_daemon --start --background --pidfile "${PID_FILE}" --make-pidfile -- \
    /usr/bin/jchroot -e HOME=/var/lib/tor --user=tor --group=tor /chroot/tor -- \
    /usr/bin/tor -f /etc/tor/torrc

eend "$?" || return 1

ebegin "Updating ${PID_FILE} with actual PID of Tor"

local jchroot_pid tor_pid

read jchroot_pid < "${PID_FILE}" && [ -n "${jchroot_pid}" ] || {
    eend 1
    eerror "Failed to get PID of jchroot from ${PID_FILE}"
    return 1
}

sleep "${CHROOT_JCHROOT_CHILD_WAIT}"

tor_pid=$(pgrep -P "${jchroot_pid}")

if [ -z "${tor_pid}" ]; then
    eend 1
    eerror "Failed to get PID of Tor based on its parent jcrhoot's PID ${jchroot_pid}."
    eerror "If Tor actually starts, consider increasing the value of CHROOT_JCHROOT_CHILD_WAIT."
    return 1
fi

echo "${tor_pid}" > "${PID_FILE}" || {
    eend 1
    eerror "Failed to save PID ${tor_pid} to ${PID_FILE}."
    return 1
}

eend 0
```

But with the option I could simply have this:

```
start_stop_daemon --start --background -- \
    /usr/bin/jchroot --pidfile="${PID_FILE}" -e HOME=/var/lib/tor --user=tor --group=tor /chroot/tor -- \
    /usr/bin/tor -f /etc/tor/torrc

eend "$?"
```

If I also need to have the daemon running in the background as root, waiting for a ping reply, before it calls jchroot, then I could do this:

```
start_stop_daemon --start --background --pidfile "${PID_FILE}" --make-pidfile -- \
    /usr/local/sbin/wait-for-connection 10.0.0.254 \
    /usr/bin/jchroot --pidfile "${PID_FILE}" /chroot/something -- \
    /usr/bin/needs_connection
```

Where the wait-for-connection script is:

```
#!/bin/bash

[[ -t 0 ]] && trap 'exit 1' SIGINT
[[ -t 1 ]] || echo() { :; }

ping -c1 -W5 "$1" &>/dev/null || {
    until echo -n .; ping -c1 -W5 "$1" &>/dev/null; do
        (( $? > 1 )) && exit 1
    done

    echo
}

exec "${@:2}"
```

Without the option I would need to create modified version of wait-for-connection that would do the same thing as earlier.
